### PR TITLE
fix(ci): upgrade upload-artifact to v7 and add hotfix branch support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
             - develop
             - "feature/**"
             - "fix/**"
+            - "hotfix/**"
     pull_request:
         branches:
             - develop
@@ -21,9 +22,9 @@ jobs:
               env:
                   BRANCH: ${{ github.head_ref }}
               run: |
-                  if [[ ! "$BRANCH" =~ ^(feature|fix)/.+ ]]; then
+                  if [[ ! "$BRANCH" =~ ^(feature|fix|hotfix)/.+ ]]; then
                     echo "::error::Branch '$BRANCH' does not follow naming conventions."
-                    echo "::error::PR source branches must be prefixed with 'feature/' or 'fix/'."
+                    echo "::error::PR source branches must be prefixed with 'feature/', 'fix/', or 'hotfix/'."
                     exit 1
                   fi
                   echo "Branch '$BRANCH' follows naming conventions."
@@ -76,7 +77,7 @@ jobs:
                     --configuration Release --framework ${{ matrix.framework }} \
                     --logger "trx;LogFileName=test-results-otel-${{ matrix.framework }}.trx"
             - name: Upload test results
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               if: always()
               continue-on-error: true
               with:


### PR DESCRIPTION
## Summary

Upgrades `actions/upload-artifact` from `v5` to `v7` to resolve Node.js 20 deprecation warnings, and extends CI workflow support to include `hotfix/**` branches.

## Changes

- **`ci.yml`**: Add `hotfix/**` to push trigger branches
- **`ci.yml`**: Update branch validation regex to allow `hotfix/` prefix alongside `feature/` and `fix/`
- **`ci.yml`**: Bump `actions/upload-artifact@v5` → `actions/upload-artifact@v7` (Node.js 24)

## Motivation

GitHub Actions will force Node.js 24 by default from June 2, 2026 and will remove Node.js 20 runners on September 16, 2026. `v7` is the latest release of `upload-artifact` and runs on Node.js 24 natively.