### PR TITLE
fix(ci): allow 'develop' as a valid PR source branch in naming check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
               env:
                   BRANCH: ${{ github.head_ref }}
               run: |
-                  if [[ ! "$BRANCH" =~ ^(feature|fix|hotfix)/.+ ]]; then
+                  if [[ ! "$BRANCH" =~ ^(feature|fix|hotfix)/.+ ]] && [[ "$BRANCH" != "develop" ]]; then
                     echo "::error::Branch '$BRANCH' does not follow naming conventions."
-                    echo "::error::PR source branches must be prefixed with 'feature/', 'fix/', or 'hotfix/'."
+                    echo "::error::PR source branches must be 'develop' or prefixed with 'feature/', 'fix/', or 'hotfix/'."
                     exit 1
                   fi
                   echo "Branch '$BRANCH' follows naming conventions."


### PR DESCRIPTION
## Problem

PR #28 (`develop` → `master`) fails CI with:

```
Error: Branch 'develop' does not follow naming conventions.
Error: PR source branches must be prefixed with 'feature/', 'fix/', or 'hotfix/'.
```

The branch naming check only allowed `feature/`, `fix/`, and `hotfix/` prefixed branches as PR sources. `develop` is a valid integration branch that should be allowed to open PRs targeting `master`.

## Fix

Update the regex check in `.github/workflows/ci.yml` to also accept `develop` as a valid source branch, and update the error message accordingly.