### PR TITLE
fix(ci): address Copilot review recommendations from PR #28

### DIFF
--- a/ci-cd-test-run.ps1
+++ b/ci-cd-test-run.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.0
 <#
 .SYNOPSIS
     Local CI/CD test runner for Blazing.Mediator.
@@ -172,8 +173,8 @@ if ($Mode -in @('dry', 'all') -and $dockerAvailable -and $hasAct) {
             }
 
             $out = & act @actArgs 2>&1
-            # Filter known act Windows cache bug: upload-artifact@v4 fails to remove its own
-            # .gitignore on Windows, causing a non-zero exit code even in dry-run mode.
+            # Filter known act Windows cache bug: upload-artifact (all versions) may fail to
+            # remove its own .gitignore on Windows, causing a non-zero exit code even in dry-run mode.
             # Succeed if there are no real failures (excluding DRYRUN summary lines and artifact errors).
             $failed = @($out | Where-Object {
                 $_ -match '(FAIL|error)' -and

--- a/tests/OpenTelemetryExample.Tests/TelemetryIntegrationTests.cs
+++ b/tests/OpenTelemetryExample.Tests/TelemetryIntegrationTests.cs
@@ -317,7 +317,7 @@ public class TelemetryIntegrationTests : IClassFixture<OpenTelemetryWebApplicati
         // Arrange - Warm up the app first so the pressure phase measures resiliency
         // rather than cold-start timing. Use the list endpoint which always returns
         // 200 OK regardless of database state (no dependency on specific user IDs).
-        var warmUpResponse = await _client.GetAsync("/api/users");
+        using var warmUpResponse = await _client.GetAsync("/api/users");
 
         // Act - Generate a lot of requests quickly
         var tasks = new List<Task<HttpResponseMessage>>();
@@ -329,18 +329,25 @@ public class TelemetryIntegrationTests : IClassFixture<OpenTelemetryWebApplicati
 
         var responses = await Task.WhenAll(tasks);
 
-        // Assert - Burst targets a stable endpoint (GET /api/users) so the vast majority
-        // should succeed. We require ≥ 80 % to guard against regressions while still
-        // tolerating a handful of transient CI hiccups.
-        warmUpResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
-        responses.Length.ShouldBe(50);
-        var successCount = responses.Count(r => r.StatusCode == HttpStatusCode.OK);
-        successCount.ShouldBeGreaterThanOrEqualTo(40); // ≥ 80 % success under pressure
+        try
+        {
+            // Assert - Burst targets a stable endpoint (GET /api/users) so the vast majority
+            // should succeed. We require ≥ 80 % to guard against regressions while still
+            // tolerating a handful of transient CI hiccups.
+            warmUpResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+            responses.Length.ShouldBe(50);
+            var successCount = responses.Count(r => r.StatusCode == HttpStatusCode.OK);
+            successCount.ShouldBeGreaterThanOrEqualTo(40); // ≥ 80 % success under pressure
+        }
+        finally
+        {
+            Array.ForEach(responses, r => r.Dispose());
+        }
 
-        var healthResponse = await _client.GetAsync("/health");
+        using var healthResponse = await _client.GetAsync("/health");
         healthResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        var followUpResponse = await _client.GetAsync("/api/users");
+        using var followUpResponse = await _client.GetAsync("/api/users");
         followUpResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
 


### PR DESCRIPTION
Addresses all four Copilot review threads raised on PR #28.

## Changes

### `.github/workflows/ci.yml` - Thread 1
 - Already addressed in PR #29 (merged). No changes needed here.
 
 ### `ci-cd-test-run.ps1` - Thread 2
- Added `#Requires -Version 7.0` at the top of the script. The `$IsWindows` and `$IsMacOS` automatic variables are PowerShell 6+ only; without this guard, the script throws confusing errors on Windows PowerShell 5.1.

### `ci-cd-test-run.ps1` - Thread 3
- Updated the dry-run filter comment from the version-specific `upload-artifact@v4` wording to a version-agnostic phrasing, since the workflows now use `upload-artifact@v7`.

### `tests/OpenTelemetryExample.Tests/TelemetryIntegrationTests.cs` - Thread 4
- In `ApplicationUnderPressure_ContinuesWorking`, disposed all `HttpResponseMessage` instances to prevent resource leaks:
   - `warmUpResponse`, `healthResponse`, and `followUpResponse` are now declared with `using var`
   - The 50-response burst array is disposed in a `try/finally` block via `Array.ForEach(responses, r => r.Dispose())`
  
 